### PR TITLE
Remove unused mcad parameter

### DIFF
--- a/test/odh/resources/mnist_ray_mini.ipynb
+++ b/test/odh/resources/mnist_ray_mini.ipynb
@@ -81,7 +81,6 @@
     "        min_memory=1,\n",
     "        max_memory=2,\n",
     "        num_gpus=0,\n",
-    "        mcad=False,\n",
     "        image=ray_image,\n",
     "        local_queue=local_queue,\n",
     "        write_to_file=True,\n",


### PR DESCRIPTION
Mcad parameter no longer exists in ClusterConfiguration.